### PR TITLE
feat: ESM porting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .DS_Store
 package-lock.json
 .bloggify/*
+.idea

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -230,6 +230,6 @@ const parser = new ParseIt(rules);
  * @param {String} f The date format.
  * @return {String} The formatted date (as string).
  */
-module.exports = function formatoid(i, f) {
+export default function formatoid(i, f) {
     return parser.run(f, [i, i._useUTC]);
 };

--- a/package.json
+++ b/package.json
@@ -48,5 +48,11 @@
   ],
   "directories": {
     "example": "example"
+  },
+  "exports": {
+    ".": {
+      "require": "./lib/index.js",
+      "import": "./lib/index.mjs"
+    }
   }
 }


### PR DESCRIPTION
Enable ESM module by using the `import formatoid from "formatoid"` ESM syntax.